### PR TITLE
chore: move to quantcli org and migrate to homebrew_casks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,15 +25,24 @@ archives:
 checksum:
   name_template: checksums.txt
 
-brews:
+homebrew_casks:
   - name: crono-export
     repository:
-      owner: DTTerastar
+      owner: quantcli
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    homepage: https://github.com/DTTerastar/crono-export-cli
+    directory: Casks
+    homepage: https://github.com/quantcli/crono-export-cli
     description: CLI to export Cronometer nutrition, biometrics, and food log data as JSON
     license: MIT
+    url:
+      verified: github.com/quantcli/crono-export-cli
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/crono-export"]
+          end
 
 release:
   draft: true

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Export your personal nutrition, biometric, and food-log data from [Cronometer](https://cronometer.com) as JSON. Built for personal LLM agents and scripts that want structured nutrition data — for example, an LLM-driven bariatric or fitness coach that needs to know how much protein, B12, iron, or calcium you actually got today.
 
-[![Latest Release](https://img.shields.io/github/v/release/DTTerastar/crono-export-cli)](https://github.com/DTTerastar/crono-export-cli/releases/latest)
+[![Latest Release](https://img.shields.io/github/v/release/quantcli/crono-export-cli)](https://github.com/quantcli/crono-export-cli/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Go](https://img.shields.io/github/go-mod/go-version/DTTerastar/crono-export-cli)](go.mod)
+[![Go](https://img.shields.io/github/go-mod/go-version/quantcli/crono-export-cli)](go.mod)
 ![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)
 
 ## Features
@@ -20,7 +20,7 @@ Export your personal nutrition, biometric, and food-log data from [Cronometer](h
 
 ```sh
 # Install with Homebrew
-brew tap DTTerastar/tap
+brew tap quantcli/tap
 brew install crono-export
 
 # Set credentials and try a query
@@ -33,36 +33,36 @@ crono-export servings --today
 
 **Homebrew (macOS / Linux):**
 ```sh
-brew tap DTTerastar/tap
+brew tap quantcli/tap
 brew install crono-export
 ```
 
-Or download a pre-built binary from the [releases page](https://github.com/DTTerastar/crono-export-cli/releases/latest):
+Or download a pre-built binary from the [releases page](https://github.com/quantcli/crono-export-cli/releases/latest):
 
 **macOS (Apple Silicon):**
 ```sh
-curl -Lo /tmp/crono-export.zip https://github.com/DTTerastar/crono-export-cli/releases/latest/download/crono-export_darwin_arm64.zip
+curl -Lo /tmp/crono-export.zip https://github.com/quantcli/crono-export-cli/releases/latest/download/crono-export_darwin_arm64.zip
 unzip -jo /tmp/crono-export.zip -d ~/bin && rm /tmp/crono-export.zip
 chmod +x ~/bin/crono-export
 ```
 
 **macOS (Intel):**
 ```sh
-curl -Lo /tmp/crono-export.zip https://github.com/DTTerastar/crono-export-cli/releases/latest/download/crono-export_darwin_amd64.zip
+curl -Lo /tmp/crono-export.zip https://github.com/quantcli/crono-export-cli/releases/latest/download/crono-export_darwin_amd64.zip
 unzip -jo /tmp/crono-export.zip -d ~/bin && rm /tmp/crono-export.zip
 chmod +x ~/bin/crono-export
 ```
 
 **Linux (amd64):**
 ```sh
-curl -Lo /tmp/crono-export.zip https://github.com/DTTerastar/crono-export-cli/releases/latest/download/crono-export_linux_amd64.zip
+curl -Lo /tmp/crono-export.zip https://github.com/quantcli/crono-export-cli/releases/latest/download/crono-export_linux_amd64.zip
 unzip -jo /tmp/crono-export.zip -d ~/bin && rm /tmp/crono-export.zip
 chmod +x ~/bin/crono-export
 ```
 
 **Windows (amd64):**
 
-Download `crono-export_windows_amd64.zip` from the [releases page](https://github.com/DTTerastar/crono-export-cli/releases/latest), extract it, and add the directory to your PATH.
+Download `crono-export_windows_amd64.zip` from the [releases page](https://github.com/quantcli/crono-export-cli/releases/latest), extract it, and add the directory to your PATH.
 
 Make sure `~/bin` is in your `PATH`. If not, add this to your `~/.zshrc` or `~/.bashrc`:
 ```sh

--- a/cmd/biometrics.go
+++ b/cmd/biometrics.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/DTTerastar/crono-export-cli/internal/cronoclient"
+	"github.com/quantcli/crono-export-cli/internal/cronoclient"
 )
 
 var biometricsCmd = &cobra.Command{

--- a/cmd/exercises.go
+++ b/cmd/exercises.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/DTTerastar/crono-export-cli/internal/cronoclient"
+	"github.com/quantcli/crono-export-cli/internal/cronoclient"
 )
 
 var exercisesCmd = &cobra.Command{

--- a/cmd/notes.go
+++ b/cmd/notes.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/DTTerastar/crono-export-cli/internal/cronoclient"
+	"github.com/quantcli/crono-export-cli/internal/cronoclient"
 )
 
 var notesCmd = &cobra.Command{

--- a/cmd/nutrition.go
+++ b/cmd/nutrition.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/DTTerastar/crono-export-cli/internal/cronoclient"
+	"github.com/quantcli/crono-export-cli/internal/cronoclient"
 )
 
 var nutritionCmd = &cobra.Command{

--- a/cmd/servings.go
+++ b/cmd/servings.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/DTTerastar/crono-export-cli/internal/cronoclient"
+	"github.com/quantcli/crono-export-cli/internal/cronoclient"
 )
 
 var servingsCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DTTerastar/crono-export-cli
+module github.com/quantcli/crono-export-cli
 
 go 1.25.5
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/DTTerastar/crono-export-cli/cmd"
+import "github.com/quantcli/crono-export-cli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Summary
- Update module path, Go imports, README links, and goreleaser homepage from `DTTerastar` to `quantcli` (follows the repo transfer to the quantcli org)
- Migrate `brews:` → `homebrew_casks:` (the `brews:` config was deprecated in GoReleaser v2.10)
- Add `url.verified` and a post-install `xattr -dr com.apple.quarantine` hook so the unsigned macOS binary isn't blocked by Gatekeeper

## Test plan
- [ ] `go build ./...` passes (verified locally)
- [ ] On next release, confirm goreleaser publishes a cask to `quantcli/homebrew-tap` without deprecation warnings
- [ ] `brew install quantcli/tap/crono-export` works end-to-end on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)