### PR TITLE
ci: add auto-assign workflow for issues and PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,19 @@
+name: Auto Assign
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - name: 'Auto-assign issue'
+      uses: pozil/auto-assign-issue@v1
+      with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: DTTerastar
+          numOfAssignee: 1


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that auto-assigns @DTTerastar to newly opened issues and PRs

## Test plan
- [ ] Open a test issue after merge to confirm assignment fires