### PR TITLE
ci: move release trigger to 'release: published'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 permissions:
   contents: write

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,7 @@ checksum:
 
 homebrew_casks:
   - name: crono-export
+    skip_upload: auto
     repository:
       owner: quantcli
       name: homebrew-tap
@@ -45,6 +46,4 @@ homebrew_casks:
           end
 
 release:
-  draft: true
-  replace_existing_draft: true
   replace_existing_artifacts: true


### PR DESCRIPTION
## Summary

Previously: tag-push triggered goreleaser which created a draft release AND pushed the cask to the tap immediately. The draft flag only gated the GitHub release object — the Homebrew cask shipped pointing at draft-release assets that 404 for non-admins. Incoherent.

New flow:
1. `gh release create vX.Y.Z --draft --generate-notes`
2. Review the draft
3. Publish it → `release: published` event fires → goreleaser uploads binaries and pushes the cask **atomically**

## Changes

- `.github/workflows/release.yml` — trigger `on: release: types: [published]`
- `.goreleaser.yml` — drop `release.draft: true` (drafts now externally managed); add `skip_upload: auto` so prereleases don't push to tap

## Test plan

- [ ] Merge this PR
- [ ] `gh release create vX.Y.Z --draft --generate-notes`
- [ ] Publish the draft
- [ ] Verify Release workflow runs, binaries upload, cask lands in `quantcli/homebrew-tap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)