### PR TITLE
fix: --today uses local calendar date, not UTC

### DIFF
--- a/internal/cronoclient/daterange.go
+++ b/internal/cronoclient/daterange.go
@@ -12,7 +12,11 @@ import (
 
 const dateLayout = "2006-01-02"
 
-// DateRange is an inclusive [Start, End] window in UTC.
+// DateRange is an inclusive [Start, End] window.  Only the calendar date
+// (YYYY-MM-DD) of each endpoint is sent to Cronometer's export endpoints,
+// so the time-of-day and zone on these values don't round-trip — but the
+// calendar date is resolved in the user's local zone so that --today
+// matches the day the user sees in the Cronometer UI.
 type DateRange struct {
 	Start time.Time
 	End   time.Time
@@ -29,17 +33,18 @@ func AddDateRangeFlags(cmd *cobra.Command) {
 
 // ParseDateRangeFromFlags reads the date-range flags off cmd and resolves
 // them into a concrete DateRange.  Default when no flags are passed: the
-// last 7 days ending today (UTC).
+// last 7 days ending today.  "Today" is the user's local calendar day.
 func ParseDateRangeFromFlags(cmd *cobra.Command) (DateRange, error) {
 	startStr, _ := cmd.Flags().GetString("start")
 	endStr, _ := cmd.Flags().GetString("end")
 	days, _ := cmd.Flags().GetInt("days")
 	today, _ := cmd.Flags().GetBool("today")
-	return resolveDateRange(startStr, endStr, days, today, time.Now().UTC())
+	return resolveDateRange(startStr, endStr, days, today, time.Now())
 }
 
 func resolveDateRange(startStr, endStr string, days int, today bool, ref time.Time) (DateRange, error) {
-	now := ref.Truncate(24 * time.Hour)
+	y, m, d := ref.Date()
+	now := time.Date(y, m, d, 0, 0, 0, 0, ref.Location())
 	var start, end time.Time
 
 	switch {


### PR DESCRIPTION
## Summary
- `--today`, `--days N`, and the default 7-day window were computed against `time.Now().UTC()`, so west of UTC the "today" date would silently roll forward to the next day in the evening.
- Caught live: at 21:xx ET (01:xx UTC), `crono-export nutrition --today` returned `[]` because it was really asking Cronometer for *tomorrow's* UTC date; `--start 2026-04-20 --end 2026-04-20` returned the expected data.
- Fix resolves the reference day in the user's local zone so `--today` matches the day shown in the Cronometer UI. Explicit `--start`/`--end` strings are unaffected.

Also switches from `Truncate(24*time.Hour)` to `time.Date(y, m, d, 0, 0, 0, 0, loc)` for the start-of-day — `Truncate` only aligns to midnight in UTC, so it would misbehave on any non-UTC reference.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Live: at 21:58 ET, `crono-export nutrition --today` now returns populated rows for 2026-04-20 (previously returned `[]`).
- [ ] Spot-check `--days 7` and the no-flag default still produce a 7-day window ending on today's local date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)