### PR TITLE
feat: add 'auth status' subcommand

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Authentication commands",
+}
+
+var authStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Print one-line auth readiness state and exit 0 if usable",
+	Long: `Print a one-line summary of whether the CLI has the credentials it needs
+to talk to Cronometer. Exit code 0 if usable, 1 if missing.
+
+This is a local check — no network call. It only verifies the
+CRONOMETER_USERNAME and CRONOMETER_PASSWORD environment variables are set.
+The CLI logs in fresh on every invocation, so a successful status here is
+necessary but not sufficient: a wrong password will still fail at run time.
+
+Per the quantcli shared contract:
+https://github.com/quantcli/common/blob/main/CONTRACT.md#5-auth`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		user := os.Getenv("CRONOMETER_USERNAME")
+		pass := os.Getenv("CRONOMETER_PASSWORD")
+		switch {
+		case user == "" && pass == "":
+			return fmt.Errorf("missing CRONOMETER_USERNAME and CRONOMETER_PASSWORD")
+		case user == "":
+			return fmt.Errorf("missing CRONOMETER_USERNAME")
+		case pass == "":
+			return fmt.Errorf("missing CRONOMETER_PASSWORD")
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "credentials present for %s (env-var auth, no token cache)\n", user)
+		return nil
+	},
+}
+
+func init() {
+	authCmd.AddCommand(authStatusCmd)
+	rootCmd.AddCommand(authCmd)
+}

--- a/cmd/prime.go
+++ b/cmd/prime.go
@@ -33,6 +33,9 @@ AUTH
     CRONOMETER_USERNAME   your Cronometer email
     CRONOMETER_PASSWORD   your Cronometer password
 
+  'crono-export auth status' is a fast local check that exits 0 when both
+  vars are set, 1 with a clear "missing X" message otherwise.
+
 DATE FLAGS  (every export subcommand accepts these)
   --since VALUE   inclusive lower bound
   --until VALUE   inclusive upper bound; defaults to today


### PR DESCRIPTION
## Summary

Per [CONTRACT §5](https://github.com/quantcli/common/blob/main/CONTRACT.md#5-auth), every quantcli CLI exposes \`auth status\` printing a one-line readiness summary, exit 0 if usable.

For crono this introduces an \`auth\` parent command (previously absent because credentials are entirely env-var driven) with one child:

\`\`\`
$ crono-export auth status
credentials present for you@example.com (env-var auth, no token cache)
$ echo \$?
0

$ unset CRONOMETER_PASSWORD
$ crono-export auth status
error: missing CRONOMETER_PASSWORD
$ echo \$?
1
\`\`\`

Local check only — no network call. Validates env vars are set; doesn't attempt a login. Clear \"missing X\" message when one or both are absent.

## Test plan

- [x] \`go build ./...\` passes
- [x] No env vars set → exit 1, both flagged
- [x] Only \`USERNAME\` set → exit 1, only \`PASSWORD\` flagged
- [x] Both set → exit 0, prints credentials-present line

🤖 Generated with [Claude Code](https://claude.com/claude-code)