### PR TITLE
fix: replace stale --json refs in markdown footer

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -140,7 +140,7 @@ func renderServings(w io.Writer, recs gocronometer.ServingRecords) error {
 			renderServingRecord(w, r)
 		}
 	}
-	fmt.Fprintln(w, "_zero-valued nutrients omitted; use --json for the full row_")
+	fmt.Fprintln(w, "_zero-valued nutrients omitted; use --format json for the full row_")
 	return nil
 }
 
@@ -298,7 +298,7 @@ func renderNutrition(w io.Writer, rows []map[string]string) error {
 		}
 	}
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "_zero-valued nutrients omitted; use --json for the full row_")
+	fmt.Fprintln(w, "_zero-valued nutrients omitted; use --format json for the full row_")
 	return nil
 }
 


### PR DESCRIPTION
## Summary
The `--json` flag was removed in 054064e in favor of `--format json`, but two markdown footer strings (`renderServings`, `renderNutrition`) still pointed users at the dead flag — an LLM or human following the suggestion verbatim hits `error: unknown flag: --json`.

Closes #20

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `grep -rn "\-\-json" cmd/` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)