### PR TITLE
fix: pass time.Local to gocronometer parsers — closes #13

### DIFF
--- a/internal/cronoclient/client.go
+++ b/internal/cronoclient/client.go
@@ -39,7 +39,7 @@ func (c *Client) Logout() {
 
 // Servings returns parsed serving records (one row per food item logged).
 func (c *Client) Servings(ctx context.Context, rng DateRange) (any, error) {
-	recs, err := c.inner.ExportServingsParsedWithLocation(ctx, rng.Start, rng.End, time.UTC)
+	recs, err := c.inner.ExportServingsParsedWithLocation(ctx, rng.Start, rng.End, time.Local)
 	if err != nil {
 		return nil, fmt.Errorf("export servings: %w", err)
 	}
@@ -48,7 +48,7 @@ func (c *Client) Servings(ctx context.Context, rng DateRange) (any, error) {
 
 // Exercises returns parsed exercise records.
 func (c *Client) Exercises(ctx context.Context, rng DateRange) (any, error) {
-	recs, err := c.inner.ExportExercisesParsedWithLocation(ctx, rng.Start, rng.End, time.UTC)
+	recs, err := c.inner.ExportExercisesParsedWithLocation(ctx, rng.Start, rng.End, time.Local)
 	if err != nil {
 		return nil, fmt.Errorf("export exercises: %w", err)
 	}
@@ -57,7 +57,7 @@ func (c *Client) Exercises(ctx context.Context, rng DateRange) (any, error) {
 
 // Biometrics returns parsed biometric records (weight, body fat, etc.).
 func (c *Client) Biometrics(ctx context.Context, rng DateRange) (any, error) {
-	recs, err := c.inner.ExportBiometricRecordsParsedWithLocation(ctx, rng.Start, rng.End, time.UTC)
+	recs, err := c.inner.ExportBiometricRecordsParsedWithLocation(ctx, rng.Start, rng.End, time.Local)
 	if err != nil {
 		return nil, fmt.Errorf("export biometrics: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes [#13](https://github.com/quantcli/crono-export-cli/issues/13). Three call sites in \`cronoclient.Client\` hardcoded \`time.UTC\` when invoking \`ExportServingsParsedWithLocation\`, \`ExportExercisesParsedWithLocation\`, and \`ExportBiometricRecordsParsedWithLocation\`. The result was every \`RecordedTime\` emitted by these subcommands carried a UTC offset (\`...Z\`) regardless of the host zone, in direct violation of [CONTRACT §2](https://github.com/quantcli/common/blob/main/CONTRACT.md#2-timezone-policy).

Beyond the JSON cosmetic, this caused the markdown date-bucketing in \`cmd/format.go\` (\`r.RecordedTime.Format(\"2006-01-02\")\`) to compute the wrong calendar day for any host west of UTC: a record logged at 9pm local on day N bucketed one day late.

\`\`\`diff
-	recs, err := c.inner.ExportServingsParsedWithLocation(ctx, rng.Start, rng.End, time.UTC)
+	recs, err := c.inner.ExportServingsParsedWithLocation(ctx, rng.Start, rng.End, time.Local)
\`\`\`

(× 3, all in \`internal/cronoclient/client.go\`.)

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\` pass
- [x] Before:
  \`\`\`
  $ crono-export servings --since 7d --format json | jq '.[0].RecordedTime'
  \"2026-05-02T00:00:00Z\"
  \`\`\`
- [x] After:
  \`\`\`
  $ crono-export servings --since 7d --format json | jq '.[0].RecordedTime'
  \"2026-05-02T00:00:00-04:00\"
  \`\`\`
- [ ] Reviewer: confirm markdown date headings (\`## 2026-05-02\`) match the date you see in the Cronometer web UI for late-evening records

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
