### PR TITLE
ci: wire compat-test bundle from quantcli/common against crono-export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: go vet + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: go vet
+        run: go vet ./...
+      - name: go test
+        run: go test ./...
+
+  compat:
+    name: compat (CONTRACT machine-attestation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: resolve compat dependency
+        # The compat module lives at github.com/quantcli/common/compat
+        # under a subpath. `go mod tidy` materializes go.sum for it on
+        # first run; subsequent runs are cache-served.
+        run: go mod tidy
+      - name: build crono-export
+        run: go build -o /tmp/crono-export .
+      - name: run compat suite
+        env:
+          # Path the compat-tagged test reads from os.Getenv.
+          CRONO_EXPORT_BIN: /tmp/crono-export
+        run: go test -tags=compat -run TestContractDates ./...

--- a/compat_contract_test.go
+++ b/compat_contract_test.go
@@ -1,0 +1,28 @@
+//go:build compat
+
+// Compat-test entry point for crono-export-cli.
+//
+// This file is only compiled under the `compat` build tag, so it does
+// not affect the default `go test ./...` run. CI invokes it as
+// `go test -tags=compat ./...` after building the export binary and
+// exposing its path through CRONO_EXPORT_BIN.
+//
+// The actual assertions live in github.com/quantcli/common/compat.
+// Drift between this CLI and CONTRACT.md surfaces as a failure here.
+package main_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/quantcli/common/compat"
+	"github.com/quantcli/common/compat/dates"
+)
+
+func TestContractDates(t *testing.T) {
+	bin := os.Getenv("CRONO_EXPORT_BIN")
+	if bin == "" {
+		t.Skip("CRONO_EXPORT_BIN not set; skipping compat suite")
+	}
+	dates.RunContract(t, compat.Runner{Binary: bin})
+}

--- a/compat_contract_test.go
+++ b/compat_contract_test.go
@@ -24,5 +24,18 @@ func TestContractDates(t *testing.T) {
 	if bin == "" {
 		t.Skip("CRONO_EXPORT_BIN not set; skipping compat suite")
 	}
-	dates.RunContract(t, compat.Runner{Binary: bin})
+	// crono is cobra-based: --since/--until live on each data-producing
+	// subcommand, not the root binary. The compat suite dispatches per
+	// subcommand under a `subcommand=NAME/...` subtree so any single
+	// regression surfaces as a named subtest failure.
+	dates.RunContract(t, compat.Runner{
+		Binary: bin,
+		Subcommands: []string{
+			"biometrics",
+			"exercises",
+			"nutrition",
+			"servings",
+			"notes",
+		},
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.5
 
 require (
 	github.com/jrmycanady/gocronometer v1.5.1
+	github.com/quantcli/common/compat v0.0.0-20260510223424-1882283f6817
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/jrmycanady/gocronometer v1.5.1
-	github.com/quantcli/common/compat v0.0.0-20260510223424-1882283f6817
+	github.com/quantcli/common/compat v0.0.0-20260510224926-b07b0d70ee59
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/jrmycanady/gocronometer v1.5.1
-	github.com/quantcli/common/compat v0.0.0-20260510224926-b07b0d70ee59
+	github.com/quantcli/common/compat v0.0.0-20260510225630-4c588c19cd1b
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jrmycanady/gocronometer v1.5.1 h1:m2J31jEuLlL4RRdQLY33IFs4TAwmfevvJYl2SZxBSQ0=
 github.com/jrmycanady/gocronometer v1.5.1/go.mod h1:swnvYB6twU20LDzNpAz8JOX5mCHktTW06zlSXmmyZWc=
+github.com/quantcli/common/compat v0.0.0-20260510225630-4c588c19cd1b h1:fO7EfkEqzLRC8Ev22jIq05fPs+JwAB7bCDy6FA+GA5k=
+github.com/quantcli/common/compat v0.0.0-20260510225630-4c588c19cd1b/go.mod h1:VBC/zEphSZgCZS1rhWsR3A8EWYSbTkP/MwqWHL7266s=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=


### PR DESCRIPTION
## Summary

- Adds `compat_contract_test.go` (build tag `compat`) that calls `dates.RunContract` from the new conformance library in `quantcli/common`.
- Adds `.github/workflows/ci.yml` with two jobs: the existing default `go vet + test` plus a new `compat (CONTRACT machine-attestation)` job that builds the binary and runs the compat suite against it.
- Updates `go.mod` to require the compat module.

## Stacked on quantcli/common#6

This PR cannot pass CI until [quantcli/common#6](https://github.com/quantcli/common/pull/6) merges. The `require` line in `go.mod` currently points at the pseudo-version of that PR's HEAD commit (`v0.0.0-20260510223424-1882283f6817`); the Go module proxy will only serve it reliably once the commit is on `main`. Before flipping this PR out of draft I will:

1. Update the `require` line to a `main`-rooted pseudo-version (or a tagged compat release if we cut one).
2. Verify `compat` job goes green.

## What this PR implies for the other export-CLIs

Nothing yet. Crono is the first consumer by design — the library has only one consumer until LeadGoEngineer signs off on the Go-API shape (per the QUA-8 scope). Liftoff and withings follow once that review lands.

## Test plan

- [ ] Wait for quantcli/common#6 to merge.
- [ ] Update the `require` line to `main`-rooted pseudo-version.
- [ ] Confirm `compat` job is green; flip to ready-for-review.
- [ ] Merge.

Refs QUA-8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)