### PR TITLE
chore: bump go directive to 1.25.10 (clears stdlib vulns)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quantcli/crono-export-cli
 
-go 1.25.5
+go 1.25.10
 
 require (
 	github.com/jrmycanady/gocronometer v1.5.1


### PR DESCRIPTION
## Summary

Bumps the `go` directive in `go.mod` from **1.25.5** to **1.25.10** (latest 1.25.x patch). One-line change.

## Why

`govulncheck` against the previous `go 1.25.5` flagged 10 stdlib vulnerabilities in the call graph (TLS session resumption and friends):

`GO-2026-4337 / -4340 / -4341 / -4601 / -4602 / -4870 / -4918 / -4946 / -4947 / -4971`

None of these are exploitable in normal CLI usage (no public-facing network surface; all calls are outbound TLS), but they trip the new supply-chain gate landing in [`quantcli/common`](https://github.com/quantcli/common). Picking up the 1.25.10 patch closes all of them.

This mirrors the bump landing on `withings-export-cli` in [PR #35](https://github.com/quantcli/withings-export-cli/pull/35).

## Validation

Locally on this branch with Go 1.25.10:

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — no test files (parity with previous state)
- `go mod tidy` — no changes
- `govulncheck ./...` — **No vulnerabilities found** (0 callable in code, 0 in imported packages, 1 in a required-but-not-called module — pre-existing, not from this bump)

## Scope

`go.mod` only. No code changes, no dep changes, no behaviour changes.

## Refs

- `QUA-13`
- Companion bump: `liftoff-export-cli` (incoming, separate PR)
- Adoption of full supply-chain workflow on this repo is gated separately by the gocronometer GPL-2.0 resolution (`QUA-12`).