### PR TITLE
docs: add LICENSING.md referenced by README (follow-up to #37)

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,59 @@
+# Licensing history
+
+`crono-export-cli` is released under the MIT licence (see [LICENSE](LICENSE)).
+This file records the licensing history of the project so that downstream
+consumers can reason about which releases are MIT-clean.
+
+## Summary
+
+- **v1.1.0 and later — MIT-clean.** The CLI talks to Cronometer through an
+  in-tree, fresh-authored HTTP client under [`internal/cronoapi/`](internal/cronoapi).
+  Every transitive dependency reported by `go list -m all` is MIT, BSD, or
+  Apache-2.0. No GPL code is linked into the binary.
+- **v0.1.0 through v1.0.1 — linked GPL-2.0 code.** These releases imported
+  [`github.com/jrmycanady/gocronometer`](https://github.com/jrmycanady/gocronometer)
+  (GPL-2.0) as the Cronometer client and were therefore subject to GPL-2.0
+  obligations at distribution time. Users who built from those tags should
+  treat the resulting binaries as GPL-2.0.
+
+The earlier release notes have been amended to point at v1.1.0 as the first
+MIT-clean cut.
+
+## Clean-room replacement (QUA-12 / QUA-37)
+
+The replacement Cronometer client in `internal/cronoapi/` was written from a
+specification, not from the GPL source. The ground rules followed during the
+rewrite:
+
+- **Inputs allowed.** `gocronometer`'s *public* API surface (exported names
+  and signatures, visible via `go doc`) and Cronometer's own observable HTTP
+  behaviour, captured against a real account into redacted fixtures.
+- **Inputs not allowed.** `gocronometer`'s source code, internal helpers, or
+  unexported identifiers.
+- **Spec doc.** [`docs/cronometer-protocol.md`](docs/cronometer-protocol.md)
+  describes the Cronometer endpoints, GWT request/response shapes, and the
+  authentication handshake that the new client implements.
+- **Fixtures.** Recorded HTTP traces live under
+  [`internal/cronoapi/testdata/`](internal/cronoapi/testdata/) and were
+  redacted before commit (`tools/wirecap/`).
+- **Tests.** Unit tests for the new client exercise the fixtures only; they
+  do not import `gocronometer` and never have.
+
+The implementation PR ([#37](https://github.com/quantcli/crono-export-cli/pull/37))
+states explicitly that no `gocronometer` source was consulted during the
+rewrite.
+
+## Verifying MIT-cleanliness
+
+```sh
+# Confirms gocronometer is not in the build graph.
+go mod why github.com/jrmycanady/gocronometer
+# Expected: "(main module does not need package github.com/jrmycanady/gocronometer)"
+
+# Lists every module in the build graph; review for licences.
+go list -m all
+```
+
+If you discover a transitive GPL (or other copyleft) dependency in a
+v1.1.0+ release, please open an issue against `quantcli/crono-export-cli`
+so we can either drop or replace it.


### PR DESCRIPTION
## Summary

- PR #37 promised `LICENSING.md` in its description, but the file was not actually included in the merge.
- `README.md` already links to `LICENSING.md`, so the link is currently dangling on `main`.
- This PR adds `LICENSING.md` with the GPL-2.0 history, the v1.1.0 MIT-clean cut, the clean-room ground rules used in the QUA-37 rewrite, and reproducibility steps.

## Why this is a follow-up and not part of #37

The file is text-only and references the PR-#37 codebase as already-merged history. It cannot accurately describe "v1.1.0 is MIT-clean" until the v1.1.0 cut exists, so a follow-up is the natural shape.

## Acceptance impact

Satisfies [QUA-37](/QUA/issues/QUA-37) acceptance criterion #2: "`LICENSING.md` (or README section) discloses the GPL history and the MIT-clean cut."

Once merged, I'll tag `v1.1.0` to satisfy acceptance criterion #1 ("New release of `quantcli/crono-export-cli` compiles and passes compat tests with zero GPL transitive deps").

## Test plan

- [x] `LICENSING.md` resolves the dangling README link
- [x] Content matches QUA-12 plan v4 ground rules
- [x] Verifiability commands (`go mod why`, `go list -m all`) listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)