### PR TITLE
feat(cmd): add --version flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
+      - -X github.com/quantcli/crono-export-cli/cmd.version=v{{ .Version }}
 
 archives:
   - formats:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// version is overwritten at release time via
+// -ldflags "-X github.com/quantcli/crono-export-cli/cmd.version=v1.1.0".
+// Setting rootCmd.Version below makes cobra register --version for free.
+var version = "dev"
+
 var rootCmd = &cobra.Command{
-	Use:   "crono-export",
-	Short: "Export Cronometer nutrition, biometrics, and food log data",
+	Use:     "crono-export",
+	Short:   "Export Cronometer nutrition, biometrics, and food log data",
+	Version: version,
 	Long: `crono-export reads your personal Cronometer data via the same export
 endpoints the web app uses and prints it on stdout.  Default output is
 narrow, fitdown-style markdown; pass --format json for the full


### PR DESCRIPTION
## Problem

`crono-export --version` errors with `unknown flag: --version`. The binary carried no build-time version string, so there was nothing to print.

## Change

- Set cobra's `rootCmd.Version` from a package var `version` (default `"dev"`). Cobra registers `--version` (and `-v`) automatically once `Version` is non-empty — no custom subcommand.
- Inject the release tag at build time via goreleaser `ldflags`: `-X …/cmd.version=v{{ .Version }}`.

Same pattern as quantcli/withings-export-cli#44, which is already released (v1.2.0).

## Test

Manual, both paths (a build-tag injection isn't worth a unit test that would just exercise cobra):

```
$ go build -o b . && ./b --version
crono-export version dev
$ go build -ldflags "-X github.com/quantcli/crono-export-cli/cmd.version=v9.9.9" -o b . && ./b --version
crono-export version v9.9.9
```

`go vet ./...` / `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MvqxTC64Z9EEDewCUbNNo